### PR TITLE
Add Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> /home/${USERNAME}/.bashrc \
     
     # Create workspace directory in which to clone repo
-    && mkdir -p /home/${USERNAME}/infield_robotics_ws/src
+    && mkdir -p /home/${USERNAME}/infield_robotics_ws/src \
+    && chown -R ${USERNAME}:${USERNAME} /home/${USERNAME} 
 
 # ********************************************************
 # * Anything else you want to do like clean up goes here *

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+# Modified from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user
+ARG DEVCONTAINER_ROS_IMAGE_TAG=noetic
+FROM ros:${DEVCONTAINER_ROS_IMAGE_TAG}
+
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+
+    # [Optional] Source ROS when starting
+    && echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> /home/${USERNAME}/.bashrc \
+    
+    # Create workspace directory in which to clone repo
+    && mkdir -p /home/${USERNAME}/infield_robotics_ws/src
+
+# ********************************************************
+# * Anything else you want to do like clean up goes here *
+# ********************************************************
+
+# [Optional] Set the default user. Omit if you want to keep the default as root.
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+	"name": "ros",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"DEVCONTAINER_ROS_IMAGE_TAG": "noetic",
+			"USERNAME": "user"
+		}
+	},
+	"extensions": [
+		"ms-iot.vscode-ros",
+		"ms-python.python"
+	],
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/user/infield_robotics_ws/src,type=bind",
+	"workspaceFolder": "/home/user/infield_robotics_ws",
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "bash", 
+        "terminal.integrated.profiles.linux": {
+            "bash": {
+                "path": "/bin/bash"
+            }
+        }
+	}
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 results/humidity_sensors.csv
+.vscode/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains material for the Infield Robotics Workshop of the VDI-L
 - [Installation](#installation)
     - [installation in a new catkin workspace](#installation-in-a-new-catkin-workspace)
     - [installation in an existing catkin workspace](#installation-in-an-existing-catkin-workspace)
+    - [installation using VS Code Devcontainer](#installation-using-devcontainers-vs-code)
 - [Running the Excercises](#running-the-excercises)
 </details>
 
@@ -75,8 +76,10 @@ catkin_make
 -------------------------------------------------------------------------------------
 
 ### Installation using Devcontainers (VS Code)
+**NOTE: This option installs the workspace in a Docker container, unlike the above two options which install on your local system.**
+
 A Devcontainer configuration is provided in this repo under `.devcontainer` for use within VS Code. 
-Note: You will need to have Docker installed on your system in order to build the container.
+Note: You will need to have [Docker](https://docs.docker.com/get-docker/) installed on your system in order to build and run the container.
 
 1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for VS Code.
 2. From the remote connection window (found by clicking on the green icon at the bottom left of the VS Code window) choose "Reopen in Container"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # infield_robotics_workshop
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode-remote-try-java)
+
 ## About
 This repository contains material for the Infield Robotics Workshop of the VDI-Land.Technik / EurAgEng pre-conference.
 
@@ -36,7 +38,7 @@ create new catkin workspace
 mkdir -p ~/infield_robotics_ws/src
 ```
 
-swithc into that workspace
+switch into that workspace
 ```sh
 cd ~/infield_robotics_ws/src
 ```
@@ -71,6 +73,17 @@ catkin_make
 4. build using catkin_make / catkin build
 
 -------------------------------------------------------------------------------------
+
+### Installation using Devcontainers (VS Code)
+A Devcontainer configuration is provided in this repo under `.devcontainer` for use within VS Code. 
+Note: You will need to have Docker installed on your system in order to build the container.
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for VS Code.
+2. From the remote connection window (found by clicking on the green icon at the bottom left of the VS Code window) choose "Reopen in Container"
+
+The container will open in a pre-made ROS workspace directory with this respository cloned inside a `src/` subdirectory, having already run the setup script for ROS.
+
+See [here](https://code.visualstudio.com/docs/devcontainers/containers) for more information about using Devcontainers in VS Code.
 
 ## RUNNING THE EXCERCISES
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Note: You will need to have [Docker](https://docs.docker.com/get-docker/) instal
 
 1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for VS Code.
 2. From the remote connection window (found by clicking on the green icon at the bottom left of the VS Code window) choose "Reopen in Container"
+3. Build using catkin_make / catkin build
 
 The container will open in a pre-made ROS workspace directory with this respository cloned inside a `src/` subdirectory, having already run the setup script for ROS.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # infield_robotics_workshop
-[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode-remote-try-java)
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/ATB-potsdam-automation/infield_robotics_workshop)
 
 ## About
 This repository contains material for the Infield Robotics Workshop of the VDI-Land.Technik / EurAgEng pre-conference.


### PR DESCRIPTION
I'll be attending the workshop next week, and noticed that the recommended instructions for setting up included either installing in a virtual machine, or in an existing ROS1 environment. 

I personally do most of my development work inside of Dev Containers / Docker via VS Code, and so I created a DevContainer definition in this repository to use for the workshop. I thought it may be helpful to share this with any others who may be in attendance, in case it was useful to someone other than myself. Defining the Dev Container in this repository makes it easy for anyone else to spin up an identical development environment, and if the user already has Docker installed on their system, it's much faster and more lightweight than running an entire VM image.

I've updated the README accordingly to describe this third option for installation, and I've tested that all basic dependencies are present in the container, and that the local package successfully builds via `catkin_make`.