### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,12 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && mkdir -p /home/${USERNAME}/infield_robotics_ws/src \
     && chown -R ${USERNAME}:${USERNAME} /home/${USERNAME} 
 
+# Fix catkin issue in Noetic: https://answers.ros.org/question/353113/catkin-build-in-ubuntu-2004-noetic/?answer=353115#post-id-353115
+RUN apt-get update \
+    && apt-get install -y \
+        python3-catkin-tools \ 
+        python3-osrf-pycommon
+
 # ********************************************************
 # * Anything else you want to do like clean up goes here *
 # ********************************************************

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note: You will need to have [Docker](https://docs.docker.com/get-docker/) instal
 
 1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for VS Code.
 2. From the remote connection window (found by clicking on the green icon at the bottom left of the VS Code window) choose "Reopen in Container"
-3. Build using catkin_make / catkin build
+3. From the `~/infield_robotics_ws` directory in a `bash` shell, build using `catkin_make` / `catkin build`
 
 The container will open in a pre-made ROS workspace directory with this respository cloned inside a `src/` subdirectory, having already run the setup script for ROS.
 


### PR DESCRIPTION
@tschuette22 Oops, one last minor fix that didn't make it into #1:

I noticed that although `catkin_make` worked fine, `catkin build` (or rather the `catkin` command itself) was missing from the image. 

This was a specific problem with ROS Noetic as I understand, and I linked a reference to the solution in a comment in the Dockerfile. 

After rebuilding, this solves the issue and allows for usage of the `catkin` command.